### PR TITLE
Delay requests

### DIFF
--- a/src/js/content-cannergrow.js
+++ b/src/js/content-cannergrow.js
@@ -143,12 +143,14 @@
       try {
           var data = await Promise.all(
               urls.map(
-                  url =>
-                      fetch(url, {
-                        headers: new Headers({ Authorization: 'Bearer ' + token }),
-                      }).then(
-                          (response) => response.json()
-                      )));
+                  (url, index) =>
+                      new Promise(resolve => setTimeout(resolve, index * 1000))
+                          .then(() =>
+                              fetch(url, {
+                                headers: new Headers({ Authorization: 'Bearer ' + token }),
+                              }).then(
+                                  (response) => response.json()
+                              ))));
 
           return (data)
 


### PR DESCRIPTION
Fixes #1

The `x-ratelimit-remaining` count resets every 60 seconds so a simple pause for a second after each request should also be sufficient and is a little simpler than #2.